### PR TITLE
Setup CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.vs/
+.vscode/
+
+build/
+install/
+
+compile.sh
+compile.bat
+compile.cmd
+
+run.sh
+run.bat
+run.cmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.17)
+project("Key Jackpot Digital Twin")
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(glfw3 REQUIRED)
+find_package(glad REQUIRED)
+
+set(
+    LIBRARIES
+    glfw
+    glad::glad
+)
+
+set(EXECUTABLE "key_jackpot_digital_twin")
+file(GLOB_RECURSE SRC_FILES "src/**.cpp")
+add_executable(${EXECUTABLE} ${SRC_FILES})
+
+target_link_libraries(${EXECUTABLE} PRIVATE ${LIBRARIES})
+
+install(TARGETS ${EXECUTABLE} DESTINATION .)
+install(FILES $<TARGET_FILE:glfw> DESTINATION .)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 This is a digital twin of a digital system called **Key Jackpot**, inspired by the game "Key Master".
 The digital twin will mirror everything the physical system does, and it can also control it by a serial communication using MQTT.
+
 This project is made for the discipline PCS3645.
 
 ## Install Guide
@@ -17,18 +18,37 @@ In order to install the digital twin, you will need to install:
   - GLAD;
 - A build tool, such as MinGW Makefile, Ninja or Visual Studio Code;
 
-After cloning the repository, run the following command to build the source files:
+---
+
+To install the packages run the following vcpkg commands:
+
+```bash
+vcpkg install glfw3
+vcpkg install glad
+```
+
+---
+
+After cloning the repository, run the following command to build the source files.
+The CMake website has a list with all the build tools available.
+The `-DCMAKE_TOOLCHAIN_FILE` option receives the full path to the `vcpkg.cmake` file in your vcpkg installation, allowing CMake to find the installed libraries.
+
+*Note: It is also possible to install the packages manually, using the `-DCMAKE_PREFIX_PATH="/path_to_package_1;/path_to_package_2"` option to list the packages paths, separated by `;`. If using this method, there is no reason to set the `-DCMAKE_TOOLCHAIN_FILE` option.*
 
 ```bash
 cmake -S . -B build/ -G <choose your build tool> -DCMAKE_TOOLCHAIN_FILE="/your_path_to_vcpkg_installation_folder/scripts/buildsystems/vcpkg.cmake"
 ```
 
+---
+
 Use your build tool to generate the executable (the following command uses Ninja as example).
 
 ```bash
-ninja -C  build/
+ninja -C build/
 ```
 
-It is recommended to copy these commands into a .cmd or .sh file, since it is necessary to do this everytime you compile this program.
+---
+
+It is recommended to copy the `cmake` and the build tool commands into a .cmd or .sh file, since it is necessary to do this everytime you compile this program.
 
 The executable can be found inside the `build/` folder, with the specific path depending on the build tool used.


### PR DESCRIPTION
The `CMakeLists.txt` file is configured to compile all the .cpp files inside the `src` directory, and to include the GLFW3 and GLAD packages.