### PR TITLE
Change OpenGL version to 2.1

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,13 +4,14 @@
 
 int main()
 {
+	// Create window
 	Window* window = Window::getWindowInstance();
 
 	// Main while loop
 	while(window->manageWindow())
 	{
 		// Specifies a new background color, cleans the back and depth buffers and assigns a new color to it
-		glClearColor(0.07f, 0.13f, 0.20f, 1.0f);
+		glClearColor(0.06f, 0.12f, 0.20f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 		window->updateWindow();

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+// Unique window instance
 Window* Window::windowInstance = nullptr;
 
 // Private window constructor
@@ -10,13 +11,18 @@ Window::Window()
     // Initializes GLFW
 	glfwInit();
 
-	// Informs GLFW that it is being used OpenGL 3.3 and CORE profile
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	// Informs GLFW that it is being used OpenGL 2.1
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    // Does not allow resize (it would stretch the image)
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+
+    // Sets the window dimensions
+    Window::width = 800;
+    Window::height = 800;
 
 	// Creates a 800x800 window
-	glfwWindow = glfwCreateWindow(800, 800, "Key Jackpot - Digital Twin", NULL, NULL);
+	glfwWindow = glfwCreateWindow(width, height, "Key Jackpot - Digital Twin", NULL, NULL);
 
 	// Tests if the window has been successfully created
 	checkWindowCreation();
@@ -28,7 +34,7 @@ Window::Window()
 	gladLoadGL();
 
     // Normalizes window coordinates
-	glViewport(0, 0, 800, 800);
+	glViewport(0, 0, width, height);
 }
 
 // Gets the only window instance

--- a/src/Window/Window.hpp
+++ b/src/Window/Window.hpp
@@ -25,6 +25,10 @@ class Window
         // GLFW's window object
         GLFWwindow* glfwWindow;
 
+        // Window's width and height
+        unsigned int width;
+        unsigned int height;
+
         // Private constructor
         Window();
 


### PR DESCRIPTION
The OpenGL version used is set to 2.1 to add support to older devices.

The window is now unresizable to avoid stretching the image.