### PR TITLE
Fix file IO to allow program to be called anywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
 set(EXECUTABLE "key_jackpot_digital_twin")
 file(GLOB_RECURSE SRC_FILES "src/**.cpp")
 add_executable(${EXECUTABLE} ${SRC_FILES})
+file(COPY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${CMAKE_BINARY_DIR})
 
 target_include_directories(${EXECUTABLE} PRIVATE ${INCLUDES})
 
@@ -33,3 +34,4 @@ target_link_libraries(${EXECUTABLE} PRIVATE ${LIBRARIES})
 
 install(TARGETS ${EXECUTABLE} DESTINATION .)
 install(FILES $<TARGET_FILE:glfw> DESTINATION .)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION .)

--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -33,7 +33,7 @@ void Camera::moveCamera(Direction direction)
     {
         switch(direction)
         {
-            case FOWARD:
+            case FORWARD:
                 position += speed * orientation;
                 break;
             case BACKWARD:

--- a/src/Camera/Camera.hpp
+++ b/src/Camera/Camera.hpp
@@ -14,7 +14,7 @@ enum ViewMode
 // Directions for camera movement
 enum Direction
 {
-    FOWARD,
+    FORWARD,
     BACKWARD,
     LEFT,
     RIGHT,

--- a/src/Helpers/FileHandler.cpp
+++ b/src/Helpers/FileHandler.cpp
@@ -2,31 +2,51 @@
 
 #include <iostream>
 #include <fstream>
+#include <filesystem>
+
+// Initializes static variable
+std::string FileHandler::rootPath;
+
+// Sets the application's root path from the executable path
+void FileHandler::setRootPath(const char* executablePath)
+{
+    std::filesystem::path path = std::filesystem::path(executablePath).parent_path();
+    rootPath = path.string().append("/");
+}
+
+// Returns a string with the full file path
+std::string FileHandler::getPath(const char* location, const char* fileName)
+{
+    return rootPath + location + fileName;
+}
 
 // Returns a string containing the file contents
-std::string get_file_contents(const char* file_name)
+std::string FileHandler::getFileContents(const char* location, const char* fileName)
 {
+    // Sets the path for the file
+    std::string filePath = rootPath + location + fileName;
+
     // Tries to open the file
-    std::ifstream input_file(file_name, std::ios::binary);
+    std::ifstream inputFile(filePath, std::ios::binary);
 
     // Checks for errors when opening the file
-    if(!input_file)
+    if(!inputFile)
     {
-        std::cerr << "File " << file_name << " was not found." << std::endl;
+        std::cerr << "File " << fileName << " was not found at " << filePath << "." << std::endl;
         throw(errno);
         return NULL;
     }
 
     // Moves the read position to the end of the file, and resizes the string accordingly
     std::string contents;
-    input_file.seekg(0, std::ios::end);
-    contents.resize(input_file.tellg());
+    inputFile.seekg(0, std::ios::end);
+    contents.resize(inputFile.tellg());
     // Moves the read position back to the beggining of the file
-    input_file.seekg(0, std::ios::beg);
+    inputFile.seekg(0, std::ios::beg);
 
     // Copies the file contents to the string and closes the file
-    input_file.read(&contents[0], contents.size());
-    input_file.close();
+    inputFile.read(&contents[0], contents.size());
+    inputFile.close();
 
     return contents;
 }

--- a/src/Helpers/FileHandler.hpp
+++ b/src/Helpers/FileHandler.hpp
@@ -2,5 +2,17 @@
 
 #include <string>
 
-// Returns a string containing the file contents
-std::string get_file_contents(const char* file_name);
+class FileHandler
+{
+    public:
+        // Sets the application's root path from the executable path
+        static void setRootPath(const char* executablePath);
+
+        // Returns a string with the full file path
+        static std::string getPath(const char* location, const char* fileName);
+        // Returns a string containing the file contents
+        static std::string getFileContents(const char* location, const char* fileName);
+
+        // Path for the executable
+        static std::string rootPath;
+};

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,10 +1,17 @@
+#include "Helpers/FileHandler.hpp"
 #include "Window/Window.hpp"
 #include "Window/KeyInput.hpp"
 #include "Camera/Camera.hpp"
 #include "Model/Model.hpp"
 
-int main()
+int main(int argc, char** argv)
 {
+	// Sets the path for the executable
+	if(argc > 0)
+		FileHandler::setRootPath(argv[0]);
+	else
+		return -1;
+
 	// Create window
 	Window* window = Window::getWindowInstance();
 	// Creates camera
@@ -13,10 +20,10 @@ int main()
 	KeyInput keyInput(&camera);
 
 	// Creates the default shader program
-	ShaderProgram defaultShader("../resources/Shaders/Default.vert", "../resources/Shaders/Default.frag");
+	ShaderProgram defaultShader("Default.vert", "Default.frag");
 
 	// Creates the model for the base of the structure
-	Model base("../resources/Models/Base/Base.gltf", defaultShader);
+	Model base("Base/Base.gltf", defaultShader);
 	base.setScale(0.04f);
 
 	// Enables depth test to only render the closest surface

--- a/src/Model/Mesh/ShaderProgram.cpp
+++ b/src/Model/Mesh/ShaderProgram.cpp
@@ -8,8 +8,8 @@
 ShaderProgram::ShaderProgram(const char *vertexFile, const char *fragmentFile)
 {
     // Reads the vertex and fragment shaders files and stores them in character arrays
-    std::string vertexCode = get_file_contents(vertexFile);
-    std::string fragmentCode = get_file_contents(fragmentFile);
+    std::string vertexCode = FileHandler::getFileContents("resources/Shaders/", vertexFile);
+    std::string fragmentCode = FileHandler::getFileContents("resources/Shaders/", fragmentFile);
 
     const char* vertexSource = vertexCode.c_str();
     const char* fragmentSource = fragmentCode.c_str();

--- a/src/Model/Mesh/Texture.cpp
+++ b/src/Model/Mesh/Texture.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <stb_image.h>
 
+#include "../../Helpers/FileHandler.hpp"
+
 // Texture constructor
 Texture::Texture(const char* imageFile, GLuint slot)
 {
@@ -11,9 +13,12 @@ Texture::Texture(const char* imageFile, GLuint slot)
     // Flips the image to not appear upside down
     stbi_set_flip_vertically_on_load(true);
 
+    // Gets the path to the image file
+    std::string imagePath = FileHandler::getPath("resources/Models/", imageFile);
+
     // Loads the texture image and its parameters
     int width, height, numberColorChannels;
-    unsigned char* imageBytes = stbi_load(imageFile, &width, &height, &numberColorChannels, 0);
+    unsigned char* imageBytes = stbi_load(imagePath.c_str(), &width, &height, &numberColorChannels, 0);
 
     // Generates an OpenGL texture object
     glGenTextures(1, &ID);

--- a/src/Model/ModelLoader.cpp
+++ b/src/Model/ModelLoader.cpp
@@ -19,7 +19,7 @@ ModelLoader::ModelLoader
 )
 {
     file = modelFile;
-    std::string text = get_file_contents(file);
+    std::string text = FileHandler::getFileContents("resources/Models/", file);
     JSON = nlohmann::json::parse(text);
 
     shaderProgram = &shader;
@@ -41,7 +41,7 @@ void ModelLoader::getJSONData()
     // Puts the file's content into a string
     std::string fileStr = std::string(file);
     std::string fileDirectory = fileStr.substr(0, fileStr.find_last_of('/') + 1);
-    std::string bytesText = get_file_contents((fileDirectory + uri).c_str());
+    std::string bytesText = FileHandler::getFileContents("resources/Models/", (fileDirectory + uri).c_str());
 
     // Puts the file's content into a char vector
     data = std::vector<unsigned char>(bytesText.begin(), bytesText.end());

--- a/src/Window/KeyInput.cpp
+++ b/src/Window/KeyInput.cpp
@@ -20,7 +20,7 @@ void KeyInput::handleInputs()
 
     // Camera movement
     if(glfwGetKey(win, GLFW_KEY_W) == GLFW_PRESS)               // W
-        camera->moveCamera(FOWARD);                             // Moves camera foward
+        camera->moveCamera(FORWARD);                            // Moves camera foward
     if(glfwGetKey(win, GLFW_KEY_S) == GLFW_PRESS)               // S
         camera->moveCamera(BACKWARD);                           // Moves camera backward
     if(glfwGetKey(win, GLFW_KEY_A) == GLFW_PRESS)               // A


### PR DESCRIPTION
Instead of using a relative path based on the current working directory, from where the program was called, it uses the executable path as reference. It allows the program to be called from anywhere.