### PR TITLE
Fix camera rotation in locked view

### DIFF
--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -17,7 +17,7 @@ void Camera::changeView(ViewMode mode)
     // Configures the change to locked view
     if(viewMode != LOCKED_VIEW && mode == LOCKED_VIEW)
     {
-        position = glm::vec3(0.0f, 350.0f, 350.0f);
+        position = glm::vec3(0.0f, 400.0f, 350.0f);
         orientation = glm::normalize(-position);
         positionAngle = 0.0f;
     }
@@ -58,13 +58,13 @@ void Camera::moveCamera(Direction direction)
         switch(direction)
         {
             case LEFT:
-                positionAngle -= speed;
+                positionAngle -= 0.05f * speed;
                 break;
             case RIGHT:
-                positionAngle += speed;
+                positionAngle += 0.05f * speed;
                 break;
         }
-        position = 350.0f * glm::vec3(glm::sin(positionAngle), 1.0f, glm::cos(positionAngle));
+        position = 350.0f * glm::vec3(glm::sin(positionAngle), 1.142857143f, glm::cos(positionAngle));
         orientation = glm::normalize(-position);
     }
 }
@@ -115,7 +115,7 @@ bool Camera::rotateCamera(float mouseX, float mouseY)
         else if(viewMode == LOCKED_VIEW)    // Locked view
         {
             positionAngle += rotationY;
-            position = 350.0f * glm::vec3(glm::sin(positionAngle), 1.0f, glm::cos(positionAngle));
+            position = 350.0f * glm::vec3(glm::sin(positionAngle), 1.142857143f, glm::cos(positionAngle));
             orientation = glm::normalize(-position);
         }
         // Recenters the cursor

--- a/src/Camera/Camera.hpp
+++ b/src/Camera/Camera.hpp
@@ -49,8 +49,8 @@ class Camera
         ViewMode viewMode;
 
         // Camera position, orientation with initial values
-        glm::vec3 position = glm::vec3(0.0f, 350.0f, 350.0f);
-        glm::vec3 orientation = glm::vec3(0.0f, -0.7071f, -0.7071f);
+        glm::vec3 position = glm::vec3(0.0f, 400.0f, 350.0f);
+        glm::vec3 orientation = glm::vec3(0.0f, -0.752576695f, -0.658504608f);
         // Camera tranformation matrix (for perspective)
         glm::mat4 cameraMatrix = glm::mat4(1.0f);
 


### PR DESCRIPTION
When using A or D to rotate the camera in the locked view, the angular speed was way too fast.