### PR TITLE
Add specular light

### DIFF
--- a/resources/Shaders/Default.frag
+++ b/resources/Shaders/Default.frag
@@ -2,10 +2,15 @@
 
 // Inputs the texture coordinates
 varying vec2 texCoord;
+// Inputs the normal vectors
 varying vec3 normal;
+// Inputs the current position
+varying vec3 currentPosition;
 
 // Gets the texture unit
 uniform sampler2D diffuse;
+// Gets the camera position
+uniform vec3 cameraPosition;
 
 void main()
 {
@@ -22,6 +27,15 @@ void main()
     float diffuseIntensity1 = max(0.25f * dot(normalizedNormal, lightDirection1), 0.0f);
     float diffuseIntensity = diffuseIntensity0 + diffuseIntensity1;
 
+    // Specular lightning
+    float specularLight = 0.20f;
+    vec3 viewDirection = normalize(cameraPosition - currentPosition);
+    vec3 reflectionDirection0 = reflect(-lightDirection0, normalizedNormal);
+    vec3 reflectionDirection1 = reflect(-lightDirection1, normalizedNormal);
+    float specularAmount0 = pow(max(dot(viewDirection, reflectionDirection0), 0.0f), 4);
+    float specularAmount1 = pow(max(dot(viewDirection, reflectionDirection1), 0.0f), 4);
+    float specular = (specularAmount0 + specularAmount1) * specularLight;
+
     // Outputs the color using RGBA
-    gl_FragColor = texture2D(diffuse, texCoord) * (ambientLight + diffuseIntensity);
+    gl_FragColor = texture2D(diffuse, texCoord) * (ambientLight + diffuseIntensity + specular);
 }

--- a/resources/Shaders/Default.vert
+++ b/resources/Shaders/Default.vert
@@ -14,9 +14,10 @@ uniform mat4 scale;
 // Camera matrix transformation for perspective
 uniform mat4 camera;
 
-// Outputs the texture coordinates and normal vectors to the fragment shader
+// Outputs the texture coordinates, normal vectors and current position to the fragment shader
 varying vec2 texCoord;
 varying vec3 normal;
+varying vec3 currentPos;
 
 void main()
 {
@@ -27,6 +28,7 @@ void main()
 
     // Applies the transformation matrices
     vec4 currentPosition = translation * rotation * scale * vec4(aPos, 1.0f);
+    currentPos = vec3(currentPosition.x, currentPosition.y, currentPosition.z);
     // Applies perspective and outputs the final vertex position
     gl_Position = camera * currentPosition;
 }

--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -150,3 +150,10 @@ void Camera::exportMatrix(ShaderProgram& shader, const char* uniform)
     GLint location = glGetUniformLocation(shader.ID, uniform);
     glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(cameraMatrix));
 }
+
+// Exports the position vector to the fragment shader
+void Camera::exportPosition(ShaderProgram& shader, const char* uniform)
+{
+    GLint location = glGetUniformLocation(shader.ID, uniform);
+    glUniform3fv(location, 1, glm::value_ptr(position));
+}

--- a/src/Camera/Camera.hpp
+++ b/src/Camera/Camera.hpp
@@ -43,6 +43,8 @@ class Camera
         void updateMatrix();
         // Exports the tranformation matrix to the vertex shader
         void exportMatrix(ShaderProgram& shader, const char* uniform);
+        // Exports the position vector to the fragment shader
+        void exportPosition(ShaderProgram& shader, const char* uniform);
 
     private:
         // Selects the view mode for the camera

--- a/src/Model/Mesh/Mesh.cpp
+++ b/src/Model/Mesh/Mesh.cpp
@@ -57,6 +57,7 @@ void Mesh::draw(Camera& camera, glm::vec3 translation, glm::quat rotation, glm::
     glUniformMatrix4fv(rotation_location, 1, GL_FALSE, glm::value_ptr(rotation_mat4));
     glUniformMatrix4fv(scale_location, 1, GL_FALSE, glm::value_ptr(scale_mat4));
     camera.exportMatrix(*shaderProgram, "camera");
+    camera.exportPosition(*shaderProgram, "cameraPosition");
 
     // Draws the mesh triangles using the GL_TRIANGLES primitive
     glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);


### PR DESCRIPTION
When the camera is positioned where the light source can be directly reflected on a surface, the light gets more intense on this surface.

Due to limited time, the diffuse texture was used instead of a specular map.